### PR TITLE
Update versions for gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    puma (3.4.0)
-    rack (1.6.4)
+    puma (3.10.0)
+    rack (2.0.3)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
I've updated the versions for the gems to the latest ones. The reason for this is that I'm building a fedora26-based s2i image for openshift and would like to use this as a example app. At current state it breaks on this [issue in puma gem](https://github.com/puma/puma/issues/1136).

I've tried this with Ruby 2.2 and 2.3 from Openshift catalog and it appears to work.