### PR TITLE
Update README to reference Ruby 2.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ These steps assume your OpenShift deployment has the default set of ImageStreams
 1. Fork a copy of [ruby-ex](https://github.com/openshift/ruby-ex)
 2. Add a Ruby application from your new repository:
 
-		$ oc new-app openshift/ruby-20-centos7~https://github.com/< yourusername >/ruby-ex 
+		$ oc new-app openshift/ruby-24-centos7~https://github.com/< yourusername >/ruby-ex 
 
 3. A build should start immediately.  To run another build, run:
 


### PR DESCRIPTION
Ruby 2.0 is now deprecated: https://access.redhat.com/articles/2176281